### PR TITLE
Add version number based on git tag and -V to print version number. 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,21 +17,16 @@ COMMIT_HASH?=$(shell git log --pretty=format:'%H' -n 1)
 TAG?=$(shell git describe --tags)
 BRANCH?=$(shell git rev-parse --abbrev-ref HEAD)
 CHANGES?=$(shell git status -s | grep -v '?? ')
-TAG_COMMIT_HASH?=$(shell git show-ref --tags | grep $(TAG) | cut -f 1 -d ' ')
 
+# Prefix with any development branch.
 ifeq ($(BRANCH),master)
   BRANCH:=
 else
   BRANCH:=$(BRANCH)_
 endif
 
-ifeq ($(COMMIT),$(TAG_COMMIT))
-  # Exactly on the tagged commit. The version is the tag!
-  VERSION:=$(BRANCH)$(TAG)
-else
-  # We are on a commit after the tag!
-  VERSION:=$(BRANCH)$(TAG)++
-endif
+# The version is the git tag or tag-N-hash if there are N commits after the tag.
+VERSION:=$(BRANCH)$(TAG)
 
 ifneq ($(strip $(CHANGES)),)
   # There are local non-committed changes! Add this to the version string as well!

--- a/Makefile
+++ b/Makefile
@@ -10,15 +10,54 @@ CFLAGS_WARNINGS?=-Wall -W -Waggregate-return -Wbad-function-cast -Wcast-align -W
 LIB?=-lm
 SRC=rtl_wmbus.c
 
-all: $(OUTDIR) release
+$(shell $(MKDIR) -p $(OUTDIR))
 
-$(OUTDIR):
-	$(MKDIR) -p "$(OUTDIR)"
+# Create a version number based on the latest git tag.
+COMMIT_HASH?=$(shell git log --pretty=format:'%H' -n 1)
+TAG?=$(shell git describe --tags)
+BRANCH?=$(shell git rev-parse --abbrev-ref HEAD)
+CHANGES?=$(shell git status -s | grep -v '?? ')
+TAG_COMMIT_HASH?=$(shell git show-ref --tags | grep $(TAG) | cut -f 1 -d ' ')
 
-release: $(OUTDIR)
+ifeq ($(BRANCH),master)
+  BRANCH:=
+else
+  BRANCH:=$(BRANCH)_
+endif
+
+ifeq ($(COMMIT),$(TAG_COMMIT))
+  # Exactly on the tagged commit. The version is the tag!
+  VERSION:=$(BRANCH)$(TAG)
+else
+  # We are on a commit after the tag!
+  VERSION:=$(BRANCH)$(TAG)++
+endif
+
+ifneq ($(strip $(CHANGES)),)
+  # There are local non-committed changes! Add this to the version string as well!
+  VERSION:=$(VERSION) with local changes
+  COMMIT_HASH:=$(COMMIT_HASH) with local changes
+endif
+
+$(shell echo "#define VERSION \"$(VERSION)\"" > $(OUTDIR)/version.h.tmp)
+$(shell echo "#define COMMIT \"$(COMMIT_HASH)\"" >> $(OUTDIR)/version.h.tmp)
+
+PREV_VERSION=$(shell cat -n $(OUTDIR)/version.h 2> /dev/null)
+CURR_VERSION=$(shell cat -n $(OUTDIR)/version.h.tmp 2>/dev/null)
+ifneq ($(PREV_VERSION),$(CURR_VERSION))
+$(shell mv $(OUTDIR)/version.h.tmp $(OUTDIR)/version.h)
+else
+$(shell rm $(OUTDIR)/version.h.tmp)
+endif
+
+$(info Building $(VERSION))
+
+all: release
+
+release:
 	$(CC) -DNDEBUG -O3                  $(CFLAGS) $(CFLAGS_WARNINGS) -o $(OUTFILE) $(SRC) $(LIB)
 
-debug: $(OUTDIR)
+debug:
 	$(CC) -DDEBUG  -O0 -g3 -ggdb -p -pg $(CFLAGS) $(CFLAGS_WARNINGS) -o $(OUTFILE) $(SRC) $(LIB)
 
 # Will build on Raspberry Pi 1 only

--- a/rtl_wmbus.c
+++ b/rtl_wmbus.c
@@ -33,6 +33,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <fixedptc/fixedptc.h>
+#include "build/version.h"
 #include "fir.h"
 #include "iir.h"
 #include "ppf.h"
@@ -796,21 +797,27 @@ static const unsigned opts_CLOCK_LOCK_THRESHOLD_S1 = 2; // Is not implemented as
 
 static void print_usage(const char *program_name)
 {
+    fprintf(stdout, "rtl_wmbus: " VERSION "\n\n");
     fprintf(stdout, "Usage %s:\n", program_name);
     fprintf(stdout, "\t-a accelerate (use an inaccurate atan version)\n");
     fprintf(stdout, "\t-r 0 to disable run length algorithm\n");
     fprintf(stdout, "\t-t 0 to disable time2 algorithm\n");
     fprintf(stdout, "\t-d 2 set decimation rate to 2 (defaults to 2 if omitted)\n");
     fprintf(stdout, "\t-v show used algorithm in the output\n");
+    fprintf(stdout, "\t-V show version\n");
     fprintf(stdout, "\t-s receive S1 and T1/C1 datagrams simultaneously. rtl_sdr _MUST_ be set to 868.625MHz (-f 868.625M)\n");
 }
 
+static void print_version(void)
+{
+    fprintf(stdout, "rtl_wmbus: " VERSION "\n");
+}
 
 static void process_options(int argc, char *argv[])
 {
     int option;
 
-    while ((option = getopt(argc, argv, "ad:r:vst:")) != -1)
+    while ((option = getopt(argc, argv, "ad:r:vVst:")) != -1)
     {
         switch (option)
         {
@@ -847,6 +854,9 @@ static void process_options(int argc, char *argv[])
             break;
         case 'v':
             opts_show_used_algorithm = 1;
+            break;
+        case 'V':
+            print_version();
             break;
         default:
             print_usage(argv[0]);
@@ -1150,4 +1160,3 @@ int main(int argc, char *argv[])
     free(LUT_FREQUENCY_TRANSLATION_PLUS_SINE);
     return EXIT_SUCCESS;
 }
-

--- a/rtl_wmbus.c
+++ b/rtl_wmbus.c
@@ -811,6 +811,7 @@ static void print_usage(const char *program_name)
 static void print_version(void)
 {
     fprintf(stdout, "rtl_wmbus: " VERSION "\n");
+    fprintf(stdout, COMMIT "\n");
 }
 
 static void process_options(int argc, char *argv[])
@@ -857,6 +858,7 @@ static void process_options(int argc, char *argv[])
             break;
         case 'V':
             print_version();
+            exit(EXIT_SUCCESS);
             break;
         default:
             print_usage(argv[0]);


### PR DESCRIPTION
The makefile code will use the git history to create a VERSION string and a COMMIT string.
The VERSION string looks like:

1.0.1
if you have built a clean clone where the HEAD is tagged with "1.0.1"
(you do: "git tag 1.0.1" to tag the current HEAD, then "git push --tags" to push the tags to github.)

1.0.1 with local changes
if you have built 1.0.1 with un-committed changes in your repo.

1.0.1-1-gc2897ad
if you have built 1.0.1 with one committed change after the tag.

1.0.1-1-gc2897ad with local changes
if you have built 1.0.1 with one committed change and you have un-committed changes.

1.0.1-2-gc1138ec
if you have built 1.0.1 with two committed changes after the tag.

speed_1.0.1-2-gc1138ec
if you have built the development branch speed with two committed changes after the tag.

---------------------------

rtl_wmbus -V 
will print for example:

rtl_wmbus: speed_1.0.1-2-gc1138ec
c1138ece0aebecc9c4304dda958591d9cae4673c

