### PR TITLE
Fix make install to not trigger a build of rtl_wmbus.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,8 @@ pi1:
 
 rebuild: clean all
 
-install: release
+install:
+	@if [ ! -f $(OUTFILE) ] ; then echo "Cannot find the binary to install! You have to run just \"make\" first!" ; exit 1 ; fi
 	install -d $(DESTDIR)/usr/bin
 	install $(OUTFILE) $(DESTDIR)/usr/bin
 


### PR DESCRIPTION
Do not trigger a build when "make install" is executed. This prevents the compilation process to run as root and generate root-owned files. 

Also when building rtl_wmbus for deb we want to override VERSION= with the debian package version.
If the "make install" forgets to supply the exact same VERSION then it will rebuild parts of the binary, this is problematic and inconvenient. 
 